### PR TITLE
Add an 'AdvertisingConsentStatus' to handle third party SDK using binary consent for the advertising purpose.

### DIFF
--- a/smartcmp/src/androidTest/java/com/smartadserver/android/smartcmp/manager/ConsentManagerTest.java
+++ b/smartcmp/src/androidTest/java/com/smartadserver/android/smartcmp/manager/ConsentManagerTest.java
@@ -1,0 +1,200 @@
+package com.smartadserver.android.smartcmp.manager;
+
+
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+import android.support.test.InstrumentationRegistry;
+
+import com.smartadserver.android.smartcmp.Constants;
+import com.smartadserver.android.smartcmp.consentstring.ConsentString;
+import com.smartadserver.android.smartcmp.exception.UnknownVersionNumberException;
+import com.smartadserver.android.smartcmp.model.Language;
+import com.smartadserver.android.smartcmp.model.VersionConfig;
+import com.smartadserver.android.smartcmp.util.DateUtils;
+
+import junit.framework.Assert;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+
+public class ConsentManagerTest {
+
+    @Before
+    public void setUp() {
+        ConsentManager.getSharedInstance().setContext(InstrumentationRegistry.getContext());
+        cleanSharedPreferences();
+    }
+
+    @After
+    public void cleanUp() {
+        cleanSharedPreferences();
+    }
+
+    private void cleanSharedPreferences() {
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(InstrumentationRegistry.getContext());
+        SharedPreferences.Editor editor = prefs.edit();
+        String[] keys = {Constants.IABConsentKeys.ConsentString, Constants.IABConsentKeys.ParsedPurposeConsent, Constants.IABConsentKeys.ParsedVendorConsent, Constants.IABConsentKeys.SubjectToGDPR, Constants.AdvertisingConsentStatus.Key};
+        for (String key : keys) {
+            editor.remove(key);
+        }
+
+        editor.apply();
+    }
+
+    private String getStringForSharedPreferences(String key) {
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(InstrumentationRegistry.getContext());
+        return prefs.getString(key, null);
+    }
+
+    @Test
+    public void testSaveConsentString() {
+        // First value is null
+        String initialValue = getStringForSharedPreferences(Constants.IABConsentKeys.ConsentString);
+        Assert.assertNull(initialValue);
+
+        // Save string to SharedPreferences
+        String newValue = "BOEFBi5OEFBi5ABACDENABwAAAAAZoA";
+        ConsentManager.getSharedInstance().setConsentString(newValue);
+
+        String readValue = getStringForSharedPreferences(Constants.IABConsentKeys.ConsentString);
+        Assert.assertEquals(newValue, readValue);
+    }
+
+    @Test
+    public void testInvalidConsentStringIsNotSaved() {
+        // First value is null
+        String initialValue = getStringForSharedPreferences(Constants.IABConsentKeys.ConsentString);
+        Assert.assertNull(initialValue);
+
+        // try to save invalid consent string
+        String newValue = "invalidConsentString";
+        ConsentManager.getSharedInstance().setConsentString(newValue);
+
+        String readValue = getStringForSharedPreferences(Constants.IABConsentKeys.ConsentString);
+        Assert.assertNull(readValue);
+    }
+
+    @Test
+    public void testSaveGDPRStatus() {
+        // First value is null
+        String initialValue = getStringForSharedPreferences(Constants.IABConsentKeys.SubjectToGDPR);
+        Assert.assertNull(initialValue);
+
+        // Set new value
+        ConsentManager.getSharedInstance().setSubjectToGDPR(true);
+
+        // Get value from sharedPreferences
+        String readValue = getStringForSharedPreferences(Constants.IABConsentKeys.SubjectToGDPR);
+        Assert.assertEquals("1", readValue);
+    }
+
+    @Test
+    public void testSavePurpose() throws UnknownVersionNumberException {
+        // First value is null
+        String initialValue = getStringForSharedPreferences(Constants.IABConsentKeys.ParsedPurposeConsent);
+        Assert.assertNull(initialValue);
+
+        // Set new value
+        Date date = DateUtils.dateFromString("2017-11-07T18:59:04.9Z");
+
+        if (date == null) {
+            Assert.fail("Date is null");
+        }
+
+        ConsentString consentString = new ConsentString(new VersionConfig(1),
+                date,
+                date,
+                1,
+                2,
+                3,
+                new Language("en"),
+                1,
+                6,
+                new ArrayList<>(Arrays.asList(1, 2)),
+                new ArrayList<>(Arrays.asList(1, 2, 4)));
+
+        ConsentManager.getSharedInstance().setConsentString(consentString);
+
+        // Get value from sharedPreferences
+        String readValue = getStringForSharedPreferences(Constants.IABConsentKeys.ParsedPurposeConsent);
+        Assert.assertEquals("110000000000000000000000", readValue);
+    }
+
+    @Test
+    public void testSaveVendor() throws UnknownVersionNumberException {
+        // First value is null
+        String initialValue = getStringForSharedPreferences(Constants.IABConsentKeys.ParsedVendorConsent);
+        Assert.assertNull(initialValue);
+
+        // Set new value
+        Date date = DateUtils.dateFromString("2017-11-07T18:59:04.9Z");
+
+        if (date == null) {
+            Assert.fail("Date is null");
+        }
+
+        ConsentString consentString = new ConsentString(new VersionConfig(1),
+                date,
+                date,
+                1,
+                2,
+                3,
+                new Language("en"),
+                1,
+                6,
+                new ArrayList<>(Arrays.asList(1, 2)),
+                new ArrayList<>(Arrays.asList(1, 2, 4)));
+
+        ConsentManager.getSharedInstance().setConsentString(consentString);
+
+        // Get value from sharedPreferences
+        String readValue = getStringForSharedPreferences(Constants.IABConsentKeys.ParsedVendorConsent);
+        Assert.assertEquals("110100", readValue);
+    }
+
+    @Test
+    public void testSaveAdvertisingConsentStatus() throws UnknownVersionNumberException {
+        // First value is null
+        String initialValue = getStringForSharedPreferences(Constants.IABConsentKeys.ParsedVendorConsent);
+        Assert.assertNull(initialValue);
+
+        // Save a consent string that do not consent to advertising purpose
+        Date date = DateUtils.dateFromString("2017-11-07T18:59:04.9Z");
+
+        if (date == null) {
+            Assert.fail("Date is null");
+        }
+
+        ConsentString consentString1 = new ConsentString(new VersionConfig(1),
+                date,
+                date,
+                1,
+                2,
+                3,
+                new Language("en"),
+                1,
+                6,
+                new ArrayList<>(Arrays.asList(1, 2)),
+                new ArrayList<>(Arrays.asList(1, 2, 4)));
+
+        ConsentManager.getSharedInstance().setConsentString(consentString1);
+
+        // Check saved value
+        String readValue1 = getStringForSharedPreferences(Constants.AdvertisingConsentStatus.Key);
+        Assert.assertEquals("0", readValue1);
+
+        // Set a consent string that consent to advertising purpose.
+        ConsentString consentString2 = ConsentString.consentStringByAddingPurposeConsent(3, consentString1);
+        ConsentManager.getSharedInstance().setConsentString(consentString2);
+
+        // Check saved value
+        String readValue2 = getStringForSharedPreferences(Constants.AdvertisingConsentStatus.Key);
+        Assert.assertEquals("1", readValue2);
+    }
+
+}

--- a/smartcmp/src/main/java/com/smartadserver/android/smartcmp/Constants.java
+++ b/smartcmp/src/main/java/com/smartadserver/android/smartcmp/Constants.java
@@ -27,7 +27,20 @@ public class Constants {
         public static final String ParsedVendorConsent            = "IABConsent_ParsedVendorConsent";
     }
 
-    // Vendor List configuration
+    // The AdvertisingConsentStatus SharedPreferences key contains the current user consent for the advertising
+    // purpose of the current vendor list.
+    //
+    // This status is only based on the answer of the user for the advertising purpose and does not take
+    // vendors status into account. It should be used for third party advertisement SDK that are not
+    // IAB TCF compliant.
+    //
+    // Note: this key is not part of the IAB TCF specifications.
+    public class AdvertisingConsentStatus {
+        public static final int PurposeId                         = 3;
+        public static final String Key                            = "SmartCMP_advertisingConsentStatus";
+    }
+
+    // Vendor List configuration.
     public class VendorList {
         public static final String NextRefreshDate                = "smartCMP_nextRefreshDate";
 

--- a/smartcmp/src/main/java/com/smartadserver/android/smartcmp/manager/ConsentManager.java
+++ b/smartcmp/src/main/java/com/smartadserver/android/smartcmp/manager/ConsentManager.java
@@ -274,6 +274,15 @@ public class ConsentManager implements VendorListManagerListener {
     }
 
     /**
+     * Set a new Context. This method is package private for test purpose.
+     *
+     * @param context the new context to set.
+     */
+    void setContext(Context context) {
+        this.context = context;
+    }
+
+    /**
      * @return Whether the user is subject to GDPR.
      */
     @SuppressWarnings("unused")
@@ -286,15 +295,12 @@ public class ConsentManager implements VendorListManagerListener {
      *
      * @param subjectToGDPR Whether or not the user is subject to GDPR.
      */
-    @SuppressWarnings("unused")
+    @SuppressWarnings({"unused", "SameParameterValue"})
     public void setSubjectToGDPR(boolean subjectToGDPR) {
         this.subjectToGDPR = subjectToGDPR;
 
         // Save subjectToGDPR status to SharedPreferences
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
-        SharedPreferences.Editor editor = prefs.edit();
-        editor.putBoolean(Constants.IABConsentKeys.SubjectToGDPR, subjectToGDPR);
-        editor.apply();
+        saveStringInSharedPreferences(Constants.IABConsentKeys.SubjectToGDPR, subjectToGDPR ? "1" : "0");
     }
 
     /**
@@ -319,10 +325,11 @@ public class ConsentManager implements VendorListManagerListener {
 
     /**
      * Internal method to update the consent string. Will automatically store the consent string in the SharedPreferences.
+     * Note: package private for test purpose.
      *
      * @param consentString The new consent string.
      */
-    private void setConsentString(ConsentString consentString) {
+    void setConsentString(ConsentString consentString) {
         this.consentString = consentString;
 
         if (consentString == null) {

--- a/smartcmp/src/main/java/com/smartadserver/android/smartcmp/manager/ConsentManager.java
+++ b/smartcmp/src/main/java/com/smartadserver/android/smartcmp/manager/ConsentManager.java
@@ -333,6 +333,9 @@ public class ConsentManager implements VendorListManagerListener {
         saveStringInSharedPreferences(Constants.IABConsentKeys.ConsentString, consentString.getConsentString());
         saveStringInSharedPreferences(Constants.IABConsentKeys.ParsedPurposeConsent, consentString.parsedPurposeConsents());
         saveStringInSharedPreferences(Constants.IABConsentKeys.ParsedVendorConsent, consentString.parsedVendorConsents());
+
+        // Save the advertising consent status in the SharedPreferences.
+        saveStringInSharedPreferences(Constants.AdvertisingConsentStatus.Key, consentString.isPurposeAllowed(Constants.AdvertisingConsentStatus.PurposeId) ? "1" : "0");
     }
 
     /**


### PR DESCRIPTION
Some third party SDK don't handle the IAB consent string but use a binary _(yes/no)_ consent instead, only for the advertising purpose.
This PR defines a new _SharedPreferences_ key that will be updated by the _SmartCMP_ and store a binary consent (for advertising only). This key could then be used for these third party SDK.

_Note: This behavior is not part of the IAB specification and should only be used for third party SDK that don't handle the IAB consent string._