### PR TITLE
Add API to ConsentManager allowing the publisher to directly allow/revoke all purposes without prompting the consent tool UI

### DIFF
--- a/app/src/main/java/com/smartadserver/android/smartcmp/demoapp/SmartCMPDemoApplication.java
+++ b/app/src/main/java/com/smartadserver/android/smartcmp/demoapp/SmartCMPDemoApplication.java
@@ -83,8 +83,8 @@ public class SmartCMPDemoApplication extends MultiDexApplication implements Cons
         // Note: depending on the situation, you might also want to allow or revoke all purposes consents without showing
         // the consent tool. You can do it using the acceptAllPurposes() and revokeAllPurposes() methods.
 
-        // Allow all purposes consents without prompting the user, for instance if the user is not subject to GDPR (for instance,
-        // when he is living outside of the EU).
+        // Allow all purposes consents without prompting the user, for instance if the user is not subject to GDPR (when he
+        // is living outside of the EU).
         // ConsentManager.getSharedInstance().allowAllPurposes();
 
         // Revoke all purposes consents without prompting the user, for instance if the user is under 16 years old (or younger

--- a/app/src/main/java/com/smartadserver/android/smartcmp/demoapp/SmartCMPDemoApplication.java
+++ b/app/src/main/java/com/smartadserver/android/smartcmp/demoapp/SmartCMPDemoApplication.java
@@ -85,7 +85,7 @@ public class SmartCMPDemoApplication extends MultiDexApplication implements Cons
 
         // Allow all purposes consents without prompting the user, for instance if the user is not subject to GDPR (for instance,
         // when he is living outside of the EU).
-        // ConsentManager.getSharedInstance().acceptAllPurposes();
+        // ConsentManager.getSharedInstance().allowAllPurposes();
 
         // Revoke all purposes consents without prompting the user, for instance if the user is under 16 years old (or younger
         // depending on the country where the user is located).

--- a/app/src/main/java/com/smartadserver/android/smartcmp/demoapp/SmartCMPDemoApplication.java
+++ b/app/src/main/java/com/smartadserver/android/smartcmp/demoapp/SmartCMPDemoApplication.java
@@ -77,5 +77,18 @@ public class SmartCMPDemoApplication extends MultiDexApplication implements Cons
         // more details about this).
         //
         // To generate a valid IAB consent string easily, you can use the ConsentString class.
+
+        // ---------------------------------------------------------------------------------------------------------------------
+
+        // Note: depending on the situation, you might also want to allow or revoke all purposes consents without showing
+        // the consent tool. You can do it using the acceptAllPurposes() and revokeAllPurposes() methods.
+
+        // Allow all purposes consents without prompting the user, for instance if the user is not subject to GDPR (for instance,
+        // when he is living outside of the EU).
+        // ConsentManager.getSharedInstance().acceptAllPurposes();
+
+        // Revoke all purposes consents without prompting the user, for instance if the user is under 16 years old (or younger
+        // depending on the country where the user is located).
+        // ConsentManager.getSharedInstance().revokeAllPurposes();
     }
 }

--- a/smartcmp/src/androidTest/java/com/smartadserver/android/smartcmp/consentstring/ConsentStringTest.java
+++ b/smartcmp/src/androidTest/java/com/smartadserver/android/smartcmp/consentstring/ConsentStringTest.java
@@ -771,6 +771,30 @@ public class ConsentStringTest {
     }
 
     @Test
+    public void testConsentStringByAddingAllPurposesReturnNullOnWrongVendorListVersion() throws UnknownVersionNumberException {
+        Date date = DateUtils.dateFromString("2017-11-07T18:59:04.9Z");
+        Date updatedDate = DateUtils.dateFromString("2018-11-07T18:59:04.9Z");
+
+        if (date == null || updatedDate == null) {
+            Assert.fail("Date is null");
+        }
+
+        ConsentString consentString = new ConsentString(new VersionConfig(1),
+                date,
+                date,
+                1,
+                2,
+                3,
+                new Language("en"),
+                getVendorList(),
+                new ArrayList<>(Arrays.asList(1, 2)),
+                new ArrayList<>(Arrays.asList(1, 2, 4)));
+
+        ConsentString resultString = ConsentString.consentStringByAddingAllPurposeConsents(getUpdatedVendorList(), consentString);
+        Assert.assertNull(resultString);
+    }
+
+    @Test
     public void testConsentStringByRemovingAllPurposes() throws UnknownVersionNumberException {
         Date date = DateUtils.dateFromString("2017-11-07T18:59:04.9Z");
         Date updatedDate = DateUtils.dateFromString("2018-11-07T18:59:04.9Z");
@@ -804,6 +828,30 @@ public class ConsentStringTest {
         ConsentString resultString = ConsentString.consentStringByRemovingAllPurposeConsents(getVendorList(), consentString, updatedDate);
 
         Assert.assertEquals(expectedString, resultString);
+    }
+
+    @Test
+    public void testConsentStringByRemovingAllPurposesReturnNullOnWrongVendorListVersion() throws UnknownVersionNumberException {
+        Date date = DateUtils.dateFromString("2017-11-07T18:59:04.9Z");
+        Date updatedDate = DateUtils.dateFromString("2018-11-07T18:59:04.9Z");
+
+        if (date == null || updatedDate == null) {
+            Assert.fail("Date is null");
+        }
+
+        ConsentString consentString = new ConsentString(new VersionConfig(1),
+                date,
+                date,
+                1,
+                2,
+                3,
+                new Language("en"),
+                getVendorList(),
+                new ArrayList<>(Arrays.asList(1, 2)),
+                new ArrayList<>(Arrays.asList(1, 2, 4)));
+
+        ConsentString resultString = ConsentString.consentStringByRemovingAllPurposeConsents(getUpdatedVendorList(), consentString);
+        Assert.assertNull(resultString);
     }
 
     @Test

--- a/smartcmp/src/androidTest/java/com/smartadserver/android/smartcmp/consentstring/ConsentStringTest.java
+++ b/smartcmp/src/androidTest/java/com/smartadserver/android/smartcmp/consentstring/ConsentStringTest.java
@@ -735,6 +735,78 @@ public class ConsentStringTest {
     }
 
     @Test
+    public void testConsentStringByAddingAllPurposes() throws UnknownVersionNumberException {
+        Date date = DateUtils.dateFromString("2017-11-07T18:59:04.9Z");
+        Date updatedDate = DateUtils.dateFromString("2018-11-07T18:59:04.9Z");
+
+        if (date == null || updatedDate == null) {
+            Assert.fail("Date is null");
+        }
+
+        ConsentString consentString = new ConsentString(new VersionConfig(1),
+                date,
+                date,
+                1,
+                2,
+                3,
+                new Language("en"),
+                getVendorList(),
+                new ArrayList<>(Arrays.asList(1, 2)),
+                new ArrayList<>(Arrays.asList(1, 2, 4)));
+
+        ConsentString expectedString = new ConsentString(new VersionConfig(1),
+                date,
+                updatedDate,
+                1,
+                2,
+                3,
+                new Language("en"),
+                getVendorList(),
+                new ArrayList<>(Arrays.asList(1, 2, 3, 4, 5)),
+                new ArrayList<>(Arrays.asList(1, 2, 4)));
+
+        ConsentString resultString = ConsentString.consentStringByAddingAllPurposeConsents(getVendorList(), consentString, updatedDate);
+
+        Assert.assertEquals(expectedString, resultString);
+    }
+
+    @Test
+    public void testConsentStringByRemovingAllPurposes() throws UnknownVersionNumberException {
+        Date date = DateUtils.dateFromString("2017-11-07T18:59:04.9Z");
+        Date updatedDate = DateUtils.dateFromString("2018-11-07T18:59:04.9Z");
+
+        if (date == null || updatedDate == null) {
+            Assert.fail("Date is null");
+        }
+
+        ConsentString consentString = new ConsentString(new VersionConfig(1),
+                date,
+                date,
+                1,
+                2,
+                3,
+                new Language("en"),
+                getVendorList(),
+                new ArrayList<>(Arrays.asList(1, 2)),
+                new ArrayList<>(Arrays.asList(1, 2, 4)));
+
+        ConsentString expectedString = new ConsentString(new VersionConfig(1),
+                date,
+                updatedDate,
+                1,
+                2,
+                3,
+                new Language("en"),
+                getVendorList(),
+                new ArrayList<Integer>(),
+                new ArrayList<>(Arrays.asList(1, 2, 4)));
+
+        ConsentString resultString = ConsentString.consentStringByRemovingAllPurposeConsents(getVendorList(), consentString, updatedDate);
+
+        Assert.assertEquals(expectedString, resultString);
+    }
+
+    @Test
     public void testConsentStringByAddingVendor() throws UnknownVersionNumberException {
         Date date = DateUtils.dateFromString("2017-11-07T18:59:04.9Z");
         Date updatedDate = DateUtils.dateFromString("2018-11-07T18:59:04.9Z");

--- a/smartcmp/src/main/java/com/smartadserver/android/smartcmp/consentstring/ConsentString.java
+++ b/smartcmp/src/main/java/com/smartadserver/android/smartcmp/consentstring/ConsentString.java
@@ -13,6 +13,7 @@ import com.smartadserver.android.smartcmp.model.VendorList;
 import com.smartadserver.android.smartcmp.model.VersionConfig;
 import com.smartadserver.android.smartcmp.util.BitUtils;
 import com.smartadserver.android.smartcmp.util.BitsString;
+import com.smartadserver.android.smartcmp.vendorlist.VendorListManager;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -1086,11 +1087,12 @@ public class ConsentString implements Parcelable {
                 allowedVendors);
     }
 
+
     /**
      * Return a new consent string which keeps info from a previous one (generated with a previous vendor list) but gives consent for all new items (purposes and vendors).
      *
      * @param updatedVendorList     The updated vendor list.
-     * @param previousVendorList    The previous consent string that has been used to generated the previous consent string.
+     * @param previousVendorList    The previous vendor list that has been used to generate the previous consent string.
      * @param previousConsentString The previous consent string.
      * @return The new consent string.
      */
@@ -1102,7 +1104,7 @@ public class ConsentString implements Parcelable {
      * Return a new consent string which keeps info from a previous one (generated with a previous vendor list) but gives consent for all new items (purposes and vendors).
      *
      * @param updatedVendorList     The updated vendor list.
-     * @param previousVendorList    The previous consent string that has been used to generated the previous consent string.
+     * @param previousVendorList    The previous vendor list that has been used to generate the previous consent string.
      * @param previousConsentString The previous consent string.
      * @param lastUpdated           The date that will be used as last updated date.
      * @return The new consent string.
@@ -1187,6 +1189,39 @@ public class ConsentString implements Parcelable {
     }
 
     /**
+     * Return a new consent string identical to the one provided, with consents added for all purposes.
+     * <p>
+     * Note: this method will updated the version config and the last updated date.
+     *
+     * @param vendorList            The vendor list used to retrieve all purposes to consent to.
+     * @param previousConsentString The previous consent string.
+     * @return a new consent string giving consent to all purposes of the vendor list.
+     */
+    static public ConsentString consentStringByAddingAllPurposeConsents(@NonNull VendorList vendorList, @NonNull ConsentString previousConsentString) {
+        return consentStringByAddingAllPurposeConsents(vendorList, previousConsentString, new Date());
+    }
+
+    /**
+     * Return a new consent string identical to the one provided, with consents added for all purposes.
+     * <p>
+     * Note: this method will updated the version config and the last updated date.
+     *
+     * @param vendorList            The vendor list used to retrieve all purposes to consent to.
+     * @param previousConsentString The previous consent string.
+     * @param lastUpdated           The date that will be used as last updated date.
+     * @return a new consent string giving consent to all purposes of the vendor list.
+     */
+    static public ConsentString consentStringByAddingAllPurposeConsents(@NonNull VendorList vendorList, @NonNull ConsentString previousConsentString, @NonNull Date lastUpdated) {
+        ConsentString consentString = new ConsentString(previousConsentString);
+
+        for (Purpose purpose : vendorList.getPurposes()) {
+            consentString = ConsentString.consentStringByAddingPurposeConsent(purpose.getId(), consentString, lastUpdated);
+        }
+
+        return consentString;
+    }
+
+    /**
      * Return a new consent string identical to the one provided, with a consent removed for a particular purpose.
      * <p>
      * Note: this method will update the version config and the last updated date.
@@ -1227,6 +1262,39 @@ public class ConsentString implements Parcelable {
                 consentString.getMaxVendorId(),
                 allowedPurpose,
                 consentString.getAllowedVendors());
+    }
+
+    /**
+     * Return a new consent string identical to the one provided, with all consent removed for the purposes.
+     * <p>
+     * Note: this method will updated the version config and the last updated date.
+     *
+     * @param vendorList            The current vendor list.
+     * @param previousConsentString The previous consent string.
+     * @return A new consent string with all consent removed for purposes.
+     */
+    static public ConsentString consentStringByRemovingAllPurposeConsents(@NonNull VendorList vendorList, @NonNull ConsentString previousConsentString) {
+        return consentStringByRemovingAllPurposeConsents(vendorList, previousConsentString, new Date());
+    }
+
+    /**
+     * Return a new consent string identical to the one provided, with all consent removed for the purposes.
+     * <p>
+     * Note: this method will updated the version config and the last updated date.
+     *
+     * @param vendorList            The current vendor list.
+     * @param previousConsentString The previous consent string.
+     * @param lastUpdated           The date that will be used as last updated date.
+     * @return A new consent string with all consent removed for purposes.
+     */
+    static public ConsentString consentStringByRemovingAllPurposeConsents(@NonNull VendorList vendorList, @NonNull ConsentString previousConsentString, @NonNull Date lastUpdated) {
+        ConsentString consentString = new ConsentString(previousConsentString);
+
+        for (Purpose purpose : vendorList.getPurposes()) {
+            consentString = consentStringByRemovingPurposeConsent(purpose.getId(), consentString, lastUpdated);
+        }
+
+        return consentString;
     }
 
     /**

--- a/smartcmp/src/main/java/com/smartadserver/android/smartcmp/consentstring/ConsentString.java
+++ b/smartcmp/src/main/java/com/smartadserver/android/smartcmp/consentstring/ConsentString.java
@@ -3,6 +3,7 @@ package com.smartadserver.android.smartcmp.consentstring;
 import android.os.Parcel;
 import android.os.Parcelable;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import com.smartadserver.android.smartcmp.Constants;
 import com.smartadserver.android.smartcmp.exception.UnknownVersionNumberException;
@@ -1195,9 +1196,9 @@ public class ConsentString implements Parcelable {
      *
      * @param vendorList            The vendor list used to retrieve all purposes to consent to.
      * @param previousConsentString The previous consent string.
-     * @return a new consent string giving consent to all purposes of the vendor list.
+     * @return a new consent string giving consent to all purposes of the vendor list, or null if the vendor list version is not the same as the consent string's vendor list version.
      */
-    static public ConsentString consentStringByAddingAllPurposeConsents(@NonNull VendorList vendorList, @NonNull ConsentString previousConsentString) {
+    static public @Nullable ConsentString consentStringByAddingAllPurposeConsents(@NonNull VendorList vendorList, @NonNull ConsentString previousConsentString) {
         return consentStringByAddingAllPurposeConsents(vendorList, previousConsentString, new Date());
     }
 
@@ -1209,9 +1210,13 @@ public class ConsentString implements Parcelable {
      * @param vendorList            The vendor list used to retrieve all purposes to consent to.
      * @param previousConsentString The previous consent string.
      * @param lastUpdated           The date that will be used as last updated date.
-     * @return a new consent string giving consent to all purposes of the vendor list.
+     * @return a new consent string giving consent to all purposes of the vendor list, or null if the vendor list version is not the same as the consent string's vendor list version.
      */
-    static public ConsentString consentStringByAddingAllPurposeConsents(@NonNull VendorList vendorList, @NonNull ConsentString previousConsentString, @NonNull Date lastUpdated) {
+    static public @Nullable ConsentString consentStringByAddingAllPurposeConsents(@NonNull VendorList vendorList, @NonNull ConsentString previousConsentString, @NonNull Date lastUpdated) {
+        if (vendorList.getVersion() != previousConsentString.getVendorListVersion()) {
+            return null;
+        }
+
         ConsentString consentString = new ConsentString(previousConsentString);
 
         for (Purpose purpose : vendorList.getPurposes()) {
@@ -1271,9 +1276,9 @@ public class ConsentString implements Parcelable {
      *
      * @param vendorList            The current vendor list.
      * @param previousConsentString The previous consent string.
-     * @return A new consent string with all consent removed for purposes.
+     * @return A new consent string with all consent removed for purposes, or null if the vendor list version is not the same as the consent string's vendor list version.
      */
-    static public ConsentString consentStringByRemovingAllPurposeConsents(@NonNull VendorList vendorList, @NonNull ConsentString previousConsentString) {
+    static public @Nullable ConsentString consentStringByRemovingAllPurposeConsents(@NonNull VendorList vendorList, @NonNull ConsentString previousConsentString) {
         return consentStringByRemovingAllPurposeConsents(vendorList, previousConsentString, new Date());
     }
 
@@ -1285,9 +1290,13 @@ public class ConsentString implements Parcelable {
      * @param vendorList            The current vendor list.
      * @param previousConsentString The previous consent string.
      * @param lastUpdated           The date that will be used as last updated date.
-     * @return A new consent string with all consent removed for purposes.
+     * @return A new consent string with all consent removed for purposes, or null if the vendor list version is not the same as the consent string's vendor list version.
      */
-    static public ConsentString consentStringByRemovingAllPurposeConsents(@NonNull VendorList vendorList, @NonNull ConsentString previousConsentString, @NonNull Date lastUpdated) {
+    static public @Nullable ConsentString consentStringByRemovingAllPurposeConsents(@NonNull VendorList vendorList, @NonNull ConsentString previousConsentString, @NonNull Date lastUpdated) {
+        if (vendorList.getVersion() != previousConsentString.getVendorListVersion()) {
+            return null;
+        }
+
         ConsentString consentString = new ConsentString(previousConsentString);
 
         for (Purpose purpose : vendorList.getPurposes()) {

--- a/smartcmp/src/main/java/com/smartadserver/android/smartcmp/manager/ConsentManager.java
+++ b/smartcmp/src/main/java/com/smartadserver/android/smartcmp/manager/ConsentManager.java
@@ -356,7 +356,7 @@ public class ConsentManager implements VendorListManagerListener {
      * @return true if all purposes have been added correctly, false otherwise.
      */
     @SuppressWarnings("unused")
-    public boolean acceptAllPurposes() {
+    public boolean allowAllPurposes() {
         if (lastVendorList == null || !isConfigured) {
             logErrorMessage("The ConsentManager must be configured and the vendor list downloaded before adding all purposes. Please try again later.");
             return false;

--- a/smartcmp/src/main/java/com/smartadserver/android/smartcmp/manager/ConsentManager.java
+++ b/smartcmp/src/main/java/com/smartadserver/android/smartcmp/manager/ConsentManager.java
@@ -119,7 +119,7 @@ public class ConsentManager implements VendorListManagerListener {
             }
 
             // if coming from a background state, we need to enable vendors list periodical refreshes
-            if (wasBackground){
+            if (wasBackground) {
                 if (vendorListManager != null) {
                     vendorListManager.startAutomaticRefresh(false);
                 }
@@ -138,7 +138,7 @@ public class ConsentManager implements VendorListManagerListener {
             }
 
             // instantiate new check Runnable
-            checkIfBackgroundRunnable  = new Runnable(){
+            checkIfBackgroundRunnable = new Runnable() {
                 @Override
                 public void run() {
                     if (!isBackground && activityWasPaused) {
@@ -156,19 +156,24 @@ public class ConsentManager implements VendorListManagerListener {
         }
 
         @Override
-        public void onActivityCreated(Activity activity, Bundle savedInstanceState) {}
+        public void onActivityCreated(Activity activity, Bundle savedInstanceState) {
+        }
 
         @Override
-        public void onActivityStarted(Activity activity) {}
+        public void onActivityStarted(Activity activity) {
+        }
 
         @Override
-        public void onActivityStopped(Activity activity) {}
+        public void onActivityStopped(Activity activity) {
+        }
 
         @Override
-        public void onActivitySaveInstanceState(Activity activity, Bundle outState) {}
+        public void onActivitySaveInstanceState(Activity activity, Bundle outState) {
+        }
 
         @Override
-        public void onActivityDestroyed(Activity activity) {}
+        public void onActivityDestroyed(Activity activity) {
+        }
     }
 
     /**
@@ -343,6 +348,79 @@ public class ConsentManager implements VendorListManagerListener {
 
         // Save the advertising consent status in the SharedPreferences.
         saveStringInSharedPreferences(Constants.AdvertisingConsentStatus.Key, consentString.isPurposeAllowed(Constants.AdvertisingConsentStatus.PurposeId) ? "1" : "0");
+    }
+
+    /**
+     * Adds all purposes consents for the current consent string if it is already defined, create a new consent string with full consent otherwise.
+     * <p>
+     * Note: if the vendor list is not set yet, it will do nothing.
+     *
+     * @return true if all purposes have been added correctly, false otherwise.
+     */
+    public boolean acceptAllPurposes() {
+        if (lastVendorList == null || !isConfigured) {
+            logErrorMessage("The ConsentManager must be configured and the vendor list downloaded before adding all purposes. Please try again later.");
+            return false;
+        }
+
+        ConsentString consentString;
+
+        if (this.consentString != null) {
+            // The consent string is already set.
+            consentString = ConsentString.consentStringByAddingAllPurposeConsents(lastVendorList, this.consentString);
+        } else {
+            // The consent string is not set yet, so we create a consent string with full consent.
+            consentString = ConsentString.consentStringWithFullConsent(0, language, lastVendorList);
+        }
+
+        if (consentString == null) {
+            // something went wrong, return false without saving anything.
+            return false;
+        }
+
+        // Set the new consent string.
+        setConsentString(consentString);
+
+        return true;
+    }
+
+    /**
+     * Removes all purposes consents for the current consent string if it is already defined, create a new consent string with full vendors consent and no purposes consent otherwise.
+     * <p>
+     * Note: if the vendor list is not set yet, it will do nothing.
+     *
+     * @return true if all purposes have been removed correctly, false otherwise.
+     */
+    public boolean revokeAllPurposes() {
+        if (lastVendorList == null || !isConfigured) {
+            logErrorMessage("The ConsentManager must be configured and the vendor list downloaded before revoking all purposes. Please try again later.");
+            return false;
+        }
+
+        ConsentString consentString;
+
+        if (this.consentString != null) {
+            // The consent string is already set.
+            consentString = ConsentString.consentStringByRemovingAllPurposeConsents(lastVendorList, this.consentString);
+        } else {
+            // The consent string is not set yet.
+
+            // First, create a consent string with full consent.
+            consentString = ConsentString.consentStringWithFullConsent(0, language, lastVendorList);
+
+            // Then remove all purpose consents.
+            consentString = ConsentString.consentStringByRemovingAllPurposeConsents(lastVendorList, consentString);
+        }
+
+        if (consentString == null) {
+            // something went wrong, return false without saving anything.
+            return false;
+        }
+
+        // set the new consent string.
+        setConsentString(consentString);
+
+        return true;
     }
 
     /**

--- a/smartcmp/src/main/java/com/smartadserver/android/smartcmp/manager/ConsentManager.java
+++ b/smartcmp/src/main/java/com/smartadserver/android/smartcmp/manager/ConsentManager.java
@@ -352,11 +352,10 @@ public class ConsentManager implements VendorListManagerListener {
 
     /**
      * Adds all purposes consents for the current consent string if it is already defined, create a new consent string with full consent otherwise.
-     * <p>
-     * Note: if the vendor list is not set yet, it will do nothing.
      *
      * @return true if all purposes have been added correctly, false otherwise.
      */
+    @SuppressWarnings("unused")
     public boolean acceptAllPurposes() {
         if (lastVendorList == null || !isConfigured) {
             logErrorMessage("The ConsentManager must be configured and the vendor list downloaded before adding all purposes. Please try again later.");
@@ -386,11 +385,10 @@ public class ConsentManager implements VendorListManagerListener {
 
     /**
      * Removes all purposes consents for the current consent string if it is already defined, create a new consent string with full vendors consent and no purposes consent otherwise.
-     * <p>
-     * Note: if the vendor list is not set yet, it will do nothing.
      *
      * @return true if all purposes have been removed correctly, false otherwise.
      */
+    @SuppressWarnings("unused")
     public boolean revokeAllPurposes() {
         if (lastVendorList == null || !isConfigured) {
             logErrorMessage("The ConsentManager must be configured and the vendor list downloaded before revoking all purposes. Please try again later.");


### PR DESCRIPTION
Depending on the situation, the publisher might want to allow or revoke all purposes consents without showing the consent tool.

For example:
- If the user is living outside of the EU, the publisher will be able to allow all purposes by calling `ConsentManager.getSharedInstance().acceptAllPurposes();`.
- If the user is under 16 years old (or younger depending on the country where the user is located), the publisher will be able to revoke all purposes by calling `ConsentManager.getSharedInstance().revokeAllPurposes();`.