### PR TITLE
remove useless test

### DIFF
--- a/smartcmp/src/androidTest/java/com/smartadserver/android/smartcmp/model/VendorListTest.java
+++ b/smartcmp/src/androidTest/java/com/smartadserver/android/smartcmp/model/VendorListTest.java
@@ -182,12 +182,4 @@ public class VendorListTest {
         Assert.assertEquals(new ArrayList<Integer>() {{ add(1); add(3); add(4); add(5); }}, vendorList.getVendors().get(4).getLegitimatePurposes());
         Assert.assertEquals(new ArrayList<Integer>(), vendorList.getVendors().get(4).getFeatures());
     }
-
-    @Test
-    public void testLocalizedVendorListWithWrongVersionIsNotTaken() throws JSONException, MalformedURLException {
-        VendorList vendorList = new VendorList(getUpdatedVendorsJSON(), getLocalizedVendorsJSON());
-        VendorList expectedVendorList = new VendorList(getUpdatedVendorsJSON());
-
-        Assert.assertEquals(vendorList, expectedVendorList);
-    }
 }


### PR DESCRIPTION
The localized vendor list finally do not need to have the same version number as the default vendor list. So I removed the concerned test.