### PR TITLE
Fix crash when configuring ConsentManager with bad consent string in SharedPreferences

### DIFF
--- a/smartcmp/build.gradle
+++ b/smartcmp/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.library'
 
 // Current version of the cmp
-def cmpVersion = 4
-def cmpVersionName = "4"
+def cmpVersion = 5
+def cmpVersionName = "5"
 def mavenPassword = System.getenv("MAVEN_PASSWORD")
 
 group = "com.smartadserver.android"

--- a/smartcmp/src/main/java/com/smartadserver/android/smartcmp/Constants.java
+++ b/smartcmp/src/main/java/com/smartadserver/android/smartcmp/Constants.java
@@ -11,7 +11,7 @@ public class Constants {
 
         // '33' IS THE OFFICIAL CMP ID FOR SmartCMP.
         // You can use this ID as long as you don't change the source code of this project.
-        // If you d'ont use it exactly as distributed in the official Smart AdServer repository,
+        // If you don't use it exactly as distributed in the official Smart AdServer repository,
         // you must get your own CMP ID by registering here: https://register.consensu.org/CMP
         public static final int ID = 33;
         public static final int VERSION = 5;

--- a/smartcmp/src/main/java/com/smartadserver/android/smartcmp/Constants.java
+++ b/smartcmp/src/main/java/com/smartadserver/android/smartcmp/Constants.java
@@ -14,7 +14,7 @@ public class Constants {
         // If you d'ont use it exactly as distributed in the official Smart AdServer repository,
         // you must get your own CMP ID by registering here: https://register.consensu.org/CMP
         public static final int ID = 33;
-        public static final int VERSION = 4;
+        public static final int VERSION = 5;
     }
 
     // IAB Keys for SharedPreferences storage.

--- a/smartcmp/src/main/java/com/smartadserver/android/smartcmp/manager/ConsentManager.java
+++ b/smartcmp/src/main/java/com/smartadserver/android/smartcmp/manager/ConsentManager.java
@@ -255,7 +255,7 @@ public class ConsentManager implements VendorListManagerListener {
         if (rawConsentString != null) {
             try {
                 consentString = ConsentString.fromBase64String(rawConsentString);
-            } catch (UnknownVersionNumberException ignored) {
+            } catch (Exception ignored) {
             }
         }
 


### PR DESCRIPTION
When you call the `ConsentManager`'s `configure()` method with an already stored consent string in the SharedPreferences, the manager will try to decode this consent string. If this string was a bad base64, it caused a crash.