### PR TITLE
add + to XML identifier usages

### DIFF
--- a/smartcmp/src/main/res/layout/consent_tool_activity_layout.xml
+++ b/smartcmp/src/main/res/layout/consent_tool_activity_layout.xml
@@ -18,7 +18,7 @@
         android:id="@+id/main_textview"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_above="@id/manage_button"
+        android:layout_above="@+id/manage_button"
         android:layout_alignParentLeft="true"
         android:layout_alignParentStart="true"
         android:layout_below="@+id/smart_logo"
@@ -28,7 +28,7 @@
         android:id="@+id/manage_button"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_above="@id/close_button"
+        android:layout_above="@+id/close_button"
         android:layout_marginEnd="15dp"
         android:layout_marginStart="15dp" />
 

--- a/smartcmp/src/main/res/layout/consent_tool_preferences_activity_layout.xml
+++ b/smartcmp/src/main/res/layout/consent_tool_preferences_activity_layout.xml
@@ -9,7 +9,7 @@
         android:id="@+id/preferences_recycler_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_above="@id/save_button"/>
+        android:layout_above="@+id/save_button"/>
 
     <Button
         android:id="@+id/save_button"

--- a/smartcmp/src/main/res/layout/preferences_cell.xml
+++ b/smartcmp/src/main/res/layout/preferences_cell.xml
@@ -14,8 +14,8 @@
         android:layout_centerInParent="true"
         android:layout_marginLeft="8dp"
         android:layout_marginStart="8dp"
-        android:layout_toLeftOf="@id/secondary_textview"
-        android:layout_toStartOf="@id/secondary_textview"
+        android:layout_toLeftOf="@+id/secondary_textview"
+        android:layout_toStartOf="@+id/secondary_textview"
         android:text="Main textview"
         android:textColor="#000"
         tools:ignore="HardcodedText" />

--- a/smartcmp/src/main/res/layout/vendor_cell.xml
+++ b/smartcmp/src/main/res/layout/vendor_cell.xml
@@ -15,8 +15,8 @@
         android:layout_centerInParent="true"
         android:layout_marginLeft="8dp"
         android:layout_marginStart="8dp"
-        android:layout_toLeftOf="@id/clickable_zone_switch"
-        android:layout_toStartOf="@id/clickable_zone_switch"
+        android:layout_toLeftOf="@+id/clickable_zone_switch"
+        android:layout_toStartOf="@+id/clickable_zone_switch"
         android:text="Vendor Name"
         android:textColor="#000"
         tools:ignore="HardcodedText" />


### PR DESCRIPTION
I run into compilation errors that identifiers cannot be found, as they are defined after their first usage.
This pull-request adds the '+'-symbol to all xml-identifier usages to prevent such errors.