### PR TITLE
Fix potential crash when converting bits to letter

### DIFF
--- a/smartcmp/src/androidTest/java/com/smartadserver/android/smartcmp/util/BitUtilsTest.java
+++ b/smartcmp/src/androidTest/java/com/smartadserver/android/smartcmp/util/BitUtilsTest.java
@@ -92,6 +92,8 @@ public class BitUtilsTest {
         Assert.assertEquals(BitUtils.bitsToLetter("011001"), "z");
         Assert.assertNull(BitUtils.bitsToLetter(""));
         Assert.assertNull(BitUtils.bitsToLetter("a"));
+        Assert.assertNull(BitUtils.bitsToLetter("011010"));
+        Assert.assertNull(BitUtils.bitsToLetter("111111"));
     }
 
     @Test

--- a/smartcmp/src/main/java/com/smartadserver/android/smartcmp/util/BitUtils.java
+++ b/smartcmp/src/main/java/com/smartadserver/android/smartcmp/util/BitUtils.java
@@ -170,7 +170,10 @@ public class BitUtils {
         Long letterIndex = bitsToLong(bits);
 
         if (letterIndex != null) {
-            return "" + Language.VALID_LETTERS.toCharArray()[letterIndex.intValue()];
+            try {
+                return "" + Language.VALID_LETTERS.toCharArray()[letterIndex.intValue()];
+            } catch (IndexOutOfBoundsException ignored) {
+            }
         }
 
         return null;


### PR DESCRIPTION
Converting bits string to letters caused crash when the bits string value was over 26.