### PR TITLE
Make vendor list's TTL persistent

### DIFF
--- a/smartcmp/src/androidTest/java/com/smartadserver/android/smartcmp/vendorlist/VendorListManagerTest.java
+++ b/smartcmp/src/androidTest/java/com/smartadserver/android/smartcmp/vendorlist/VendorListManagerTest.java
@@ -100,7 +100,7 @@ public class VendorListManagerTest {
         };
 
 
-        VendorListManager vlManager = new VendorListManager(mockListener, 100, 10, new Language("en")) {
+        VendorListManager vlManager = new VendorListManager(InstrumentationRegistry.getContext(), mockListener, 100, 10, new Language("en")) {
             @Override
             protected JSONAsyncTask getNewJSONAsyncTaskForVendorList(@NonNull JSONAsyncTaskListener listener) {
                 return new MockJSONAsyncTask(listener) {
@@ -134,7 +134,7 @@ public class VendorListManagerTest {
             }
         };
 
-        VendorListManager vlManager = new VendorListManager(mockListener, 1000, 500, null) {
+        VendorListManager vlManager = new VendorListManager(InstrumentationRegistry.getContext(), mockListener, 1000, 500, null) {
             @Override
             protected JSONAsyncTask getNewJSONAsyncTaskForVendorList(@NonNull JSONAsyncTaskListener listener) {
                 return new MockJSONAsyncTask(listener) {
@@ -197,7 +197,7 @@ public class VendorListManagerTest {
             }
         };
 
-        VendorListManager vlManager = new VendorListManager(mockListener, 1000, 200, new Language("en")) {
+        VendorListManager vlManager = new VendorListManager(InstrumentationRegistry.getContext(), mockListener, 1000, 200, new Language("en")) {
             @Override
             protected JSONAsyncTask getNewJSONAsyncTaskForVendorList(@NonNull JSONAsyncTaskListener listener) {
                 return new MockJSONAsyncTask(listener) {
@@ -238,7 +238,7 @@ public class VendorListManagerTest {
             }
         };
 
-        VendorListManager vlManager = new VendorListManager(mockListener, 1000, 500, null) {
+        VendorListManager vlManager = new VendorListManager(InstrumentationRegistry.getContext(), mockListener, 1000, 500, null) {
             @Override
             protected JSONAsyncTask getNewJSONAsyncTaskForVendorList(@NonNull JSONAsyncTaskListener listener) {
                 return new MockJSONAsyncTask(listener) {
@@ -280,7 +280,7 @@ public class VendorListManagerTest {
             }
         };
 
-        VendorListManager vlManager = new VendorListManager(mockListener, 1000, 500, new Language("fr")) {
+        VendorListManager vlManager = new VendorListManager(InstrumentationRegistry.getContext(), mockListener, 1000, 500, new Language("fr")) {
             @Override
             protected JSONAsyncTask getNewJSONAsyncTaskForVendorList(@NonNull JSONAsyncTaskListener listener) {
                 return new MockJSONAsyncTask(listener) {
@@ -340,7 +340,7 @@ public class VendorListManagerTest {
             }
         };
 
-        VendorListManager vlManager = new VendorListManager(mockListener, 1000, 500, new Language("fr")) {
+        VendorListManager vlManager = new VendorListManager(InstrumentationRegistry.getContext(), mockListener, 1000, 500, new Language("fr")) {
             @Override
             protected JSONAsyncTask getNewJSONAsyncTaskForVendorList(@NonNull JSONAsyncTaskListener listener) {
                 return new MockJSONAsyncTask(listener) {

--- a/smartcmp/src/main/java/com/smartadserver/android/smartcmp/Constants.java
+++ b/smartcmp/src/main/java/com/smartadserver/android/smartcmp/Constants.java
@@ -47,5 +47,7 @@ public class Constants {
 
         public static final String DefaultLocalizedEndPoint       = "https://vendorlist.consensu.org/purposes-{language}.json";
         public static final String VersionedLocalizedEndPoint     = "https://vendorlist.consensu.org/purposes-{language}-{version}.json";
+
+        public static final String NextRefreshDate                = "SmartCMP_NextRefreshDate";
     }
 }

--- a/smartcmp/src/main/java/com/smartadserver/android/smartcmp/manager/ConsentManager.java
+++ b/smartcmp/src/main/java/com/smartadserver/android/smartcmp/manager/ConsentManager.java
@@ -18,7 +18,6 @@ import com.google.android.gms.common.GooglePlayServicesRepairableException;
 import com.smartadserver.android.smartcmp.Constants;
 import com.smartadserver.android.smartcmp.activity.ConsentToolActivity;
 import com.smartadserver.android.smartcmp.consentstring.ConsentString;
-import com.smartadserver.android.smartcmp.exception.UnknownVersionNumberException;
 import com.smartadserver.android.smartcmp.model.ConsentToolConfiguration;
 import com.smartadserver.android.smartcmp.model.Language;
 import com.smartadserver.android.smartcmp.model.VendorList;
@@ -37,8 +36,8 @@ public class ConsentManager implements VendorListManagerListener {
     // Default refresh interval in milliseconds (24 hours).
     static private final long DEFAULT_REFRESH_INTERVAL = 86400000;
 
-    // Default retry interval (needed after an unsuccessful refresh) in milliseconds (1 minute).
-    static private final long DEFAULT_RETRY_INTERVAL = 60000;
+    // Default poll interval (time between each refresh attempt) in milliseconds (1 minute).
+    static private final long DEFAULT_POLL_INTERVAL = 60000;
 
     // The default behavior if LAT (Limited Ad Tracking) is enabled.
     static private final boolean DEFAULT_LAT_VALUE = true;
@@ -260,8 +259,8 @@ public class ConsentManager implements VendorListManagerListener {
         }
 
         // Instantiate the VendorListManager and immediately trigger the automatic refresh.
-        vendorListManager = new VendorListManager(this, refreshingInterval, DEFAULT_RETRY_INTERVAL, language);
-        vendorListManager.startAutomaticRefresh(true);
+        vendorListManager = new VendorListManager(context, this, refreshingInterval, DEFAULT_POLL_INTERVAL, language);
+        vendorListManager.startAutomaticRefresh(false);
     }
 
     /**


### PR DESCRIPTION
This TTL is used to avoid showing the CMP again during that duration. The vendor list's TTL (24h by default) was saved dynamically, so if the user kill his app and restart it, the CMP could be displayed several time during the day, even if the TTL is set to 24h.

This Pull request avoid that behavior by using the SharedPreferences to make sure the TTL is correctly used.