### PR TITLE
Remove the consent string getter from the ConsentManager

### DIFF
--- a/smartcmp/src/main/java/com/smartadserver/android/smartcmp/manager/ConsentManager.java
+++ b/smartcmp/src/main/java/com/smartadserver/android/smartcmp/manager/ConsentManager.java
@@ -18,7 +18,6 @@ import com.google.android.gms.common.GooglePlayServicesRepairableException;
 import com.smartadserver.android.smartcmp.Constants;
 import com.smartadserver.android.smartcmp.activity.ConsentToolActivity;
 import com.smartadserver.android.smartcmp.consentstring.ConsentString;
-import com.smartadserver.android.smartcmp.exception.UnknownVersionNumberException;
 import com.smartadserver.android.smartcmp.model.ConsentToolConfiguration;
 import com.smartadserver.android.smartcmp.model.Language;
 import com.smartadserver.android.smartcmp.model.VendorList;
@@ -306,14 +305,6 @@ public class ConsentManager implements VendorListManagerListener {
 
         // Save subjectToGDPR status to SharedPreferences
         saveStringInSharedPreferences(Constants.IABConsentKeys.SubjectToGDPR, subjectToGDPR ? "1" : "0");
-    }
-
-    /**
-     * @return The consent string.
-     */
-    @SuppressWarnings("unused")
-    public ConsentString getConsentString() {
-        return consentString;
     }
 
     /**

--- a/smartcmp/src/main/java/com/smartadserver/android/smartcmp/manager/ConsentManager.java
+++ b/smartcmp/src/main/java/com/smartadserver/android/smartcmp/manager/ConsentManager.java
@@ -308,6 +308,15 @@ public class ConsentManager implements VendorListManagerListener {
     }
 
     /**
+     * Note: Package private for test purpose.
+     * @return The consent string.
+     */
+    @SuppressWarnings("unused")
+    ConsentString getConsentString() {
+        return consentString;
+    }
+
+    /**
      * Update the ConsentString using the given Base64URL encoded consent string.
      *
      * @param base64URLEncodedConsentString The base64URL encoded consent string.


### PR DESCRIPTION
The good and unique way to access the consent string should be done by using the SharedPreferences.
So the consent string getter becomes package private to only being used by tests.