### PR TITLE
Add null-checks for timer

### DIFF
--- a/smartcmp/src/main/java/com/smartadserver/android/smartcmp/vendorlist/VendorListManager.java
+++ b/smartcmp/src/main/java/com/smartadserver/android/smartcmp/vendorlist/VendorListManager.java
@@ -209,7 +209,9 @@ public class VendorListManager {
      * Disable the automatic refresh by cancelling the timer.
      */
     public void stopAutomaticRefresh() {
-        timer.cancel();
+        if (timer != null) {
+            timer.cancel();
+        }
         downloadingVendorsList = false;
         timer = null;
     }
@@ -219,7 +221,9 @@ public class VendorListManager {
      */
     public void resetTimer() {
         // Reset the timer
-        timer.cancel();
+        if (timer != null) {
+            timer.cancel();
+        }
         timer = new Timer();
 
         // reschedule the timer to refresh the vendor sooner.


### PR DESCRIPTION
We are experiencing quite a few _NullPointerExceptions_ in our application (most of them occurring when the app is in background, according to our crash reporting tool), using the latest version of this library (version 7):

```Fatal Exception: java.lang.NullPointerException
Attempt to invoke virtual method 'void java.util.Timer.cancel()' on a null object reference
at com.smartadserver.android.smartcmp.vendorlist.VendorListManager.resetTimer(VendorListManager.java:222)
at com.smartadserver.android.smartcmp.manager.ConsentManager$2.onVendorListUpdateFail(ConsentManager.java:674)
at com.smartadserver.android.smartcmp.vendorlist.VendorListManager$3.JSONAsyncTaskDidFailDownloadingJSONObject(VendorListManager.java:279)
at com.smartadserver.android.smartcmp.util.JSONAsyncTask.onPostExecute(JSONAsyncTask.java:44)
at android.os.AsyncTask.finish(AsyncTask.java:651)
[...]
```

This pull-request adds 2 simple null-checks to prevent such crashes.