### PR TITLE
Gradle update & SSL workaround for older devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,32 @@ The current version of _SmartCMP_ has the following limitations:
 * The IAB specification allows publishers to display only a subset of purposes & vendors using a _pubvendors.json_ file, stored on their own infrastructure. _SmartCMP_ does not implement this feature at this time.
 * No static texts are provided by default (you must provide them to `ConsentToolConfiguration`). The `homeScreenText` should be validated by your legal department.
 * _SmartCMP_ does not have any logic to know if GDPR applies or not based on user's location / age at this time. For the moment it is the publisher's responsibility to determine whether or not GDPR applies and if the consent tool UI should be shown to the user, as well as requesting permission to fetch location or other including / excluding criteria.
+* _SmartCMP_ is only supported on _Android 5.0+_. If you still want to use it on older Android devices, you will need to update your SSL provider.
+
+## Older Android devices: SSL provider update
+
+If you try to use _SmartCMP_ on older devices, you might have issues with the vendor list retrieval that will always fail due to a certificate error.
+
+You can workaround this issue be updating the SSL provider used by the application by importing _Google Play Services — Base_:
+
+    implementation 'com.google.android.gms:play-services-base:15.0.1'
+
+then requesting an SSL provider update just after the configure() method call by using:
+
+    // Updating the SSL provider might be necessary on older devices, otherwise HTTPS calls will fail
+    ProviderInstaller.installIfNeededAsync(this, new ProviderInstaller.ProviderInstallListener() {
+        @Override
+        public void onProviderInstalled() {
+            // Provider is up-to-date, app can make secure network calls.
+            ConsentManager.getSharedInstance().refreshVendorList();
+        }
+
+        @Override
+        public void onProviderInstallFailed(int i, Intent intent) {
+            // Provider can't be installed, SSL calls might fail
+            Log.e("SmartCMP", "Can't install/update the SSL provider, SSL calls might fail on older devices");
+        }
+    });
 
 ## License
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,16 +1,19 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
+    buildToolsVersion "28.0.3"
+
     defaultConfig {
         applicationId "com.smartadserver.android.smartcmp"
-        minSdkVersion 16
-        targetSdkVersion 27
+        minSdkVersion 21
+        targetSdkVersion 28
         versionCode 2
         versionName "2"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         multiDexEnabled true
     }
+
     buildTypes {
         release {
             minifyEnabled false
@@ -21,8 +24,8 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'com.android.support:appcompat-v7:27.1.1'
-    implementation 'com.android.support.constraint:constraint-layout:1.1.0'
+    implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation 'com.android.support.constraint:constraint-layout:1.1.3'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
+        classpath 'com.android.tools.build:gradle:3.2.0'
         
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed May 23 11:15:01 CEST 2018
+#Thu Sep 27 10:53:57 CEST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip

--- a/smartcmp/build.gradle
+++ b/smartcmp/build.gradle
@@ -30,11 +30,12 @@ uploadArchives {
 }
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
+    buildToolsVersion "28.0.3"
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 27
+        minSdkVersion 21
+        targetSdkVersion 28
         versionCode cmpVersion
         versionName cmpVersionName
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -51,15 +52,14 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
-
 }
 
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
-    implementation 'com.android.support:recyclerview-v7:27.1.1'
-    implementation 'com.android.support:appcompat-v7:27.1.1'
+    implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation 'com.android.support:recyclerview-v7:28.0.0'
 
     implementation 'com.google.android.gms:play-services-ads:15.0.1'
 


### PR DESCRIPTION
This pull request:
* updates the gradle version used to the latest one
* sets the target at API 28 & a new min SDK of API 21
* adds some information on the SSL issue on older devices and a workaround